### PR TITLE
Scipy minimize fix

### DIFF
--- a/GPflowOpt/optim.py
+++ b/GPflowOpt/optim.py
@@ -129,7 +129,8 @@ class SciPyOptimizer(Optimizer):
                            options=options)
 
     def _optimize(self, objective):
-        result = minimize(fun=objective,
+        objective1d = lambda X: tuple(map(lambda arr: arr.ravel(), objective(X)))
+        result = minimize(fun=objective1d,
                           x0=self.get_initial(),
                           jac=self.gradient_enabled(),
                           bounds=list(zip(self.domain.lower, self.domain.upper)),


### PR DESCRIPTION
Fix for SciPyOptimizer minimize issues, caused by 2D arrays returned from objective functions. 
(Done through a seperate branch as the issue does not occur on my system)