### PR TITLE
DPP designs

### DIFF
--- a/GPflowOpt/design.py
+++ b/GPflowOpt/design.py
@@ -13,6 +13,9 @@
 # limitations under the License.
 
 import numpy as np
+import GPflow
+
+from .domain import ContinuousParameter
 
 
 class Design(object):
@@ -22,8 +25,12 @@ class Design(object):
 
     def __init__(self, size, domain):
         super(Design, self).__init__()
-        self.size = size
+        self._size = size
         self.domain = domain
+
+    @property
+    def size(self):
+        return self._size
 
     def generate(self):
         raise NotImplementedError
@@ -67,3 +74,80 @@ class EmptyDesign(Design):
 
     def generate(self):
         return np.empty((0, self.domain.size))
+
+
+class DPPDesign(FactorialDesign):
+    """
+    Samples from a determinantal point process (DPP). This implementation represents the k-DPP exact sampling 
+    methodology presented in
+    ::
+       @article{Kulesza:2012,
+            title={Determinantal point processes for machine learning},
+            author={Kulesza, Alex and Taskar, Ben and others},
+            journal={Foundations and Trends in Machine Learning},
+            volume={5},
+            number={2--3},
+            pages={123--286},
+            year={2012},
+            publisher={Now Publishers, Inc.}
+       }
+    """
+
+    def __init__(self, size, domain):
+        super(DPPDesign, self).__init__(size, domain)
+        M = super(DPPDesign, self).generate()
+        gauss_kern = GPflow.kernels.RBF(domain.size, ARD=False, lengthscales=[1])
+        unit_cube = np.sum([ContinuousParameter('x{0}'.format(i), 0, 1) for i in np.arange(self.domain.size)])
+        unit_scaling = domain >> unit_cube
+        K = gauss_kern.compute_K_symm(unit_scaling.forward(M))
+
+        self.L_decomp = tuple(map(lambda l: np.real(l), np.linalg.eig(K)))
+        self._k = size
+
+    @Design.size.getter
+    def size(self):
+        return self._k
+
+    def _elementary_symmetric_polynomials(self):
+        D = self.L_decomp[0]
+        E = np.vstack((np.ones((1, D.size + 1)), np.hstack((np.zeros((self.size, 1)), np.diag(np.cumprod(D))[:self.size,:]))))
+        for i in np.arange(1, self.size + 1):
+            E[i, i:] = np.cumsum(np.hstack((E[i, i], D[i:] * E[i - 1, i:-1])))
+        return E
+
+    def _draw_k_mask(self):
+        D = self.L_decomp[0]
+        E = self._elementary_symmetric_polynomials()
+        print(E.shape)
+        r = self.size
+        j = D.size
+        mask = np.zeros((D.size,), dtype=bool)
+        while r:
+            T = 1 if j == r else D[j-1] * E[r-1, j-1] / E[r, j]
+            j -= 1
+            if np.random.rand(1) > T:
+                continue
+            mask[j] = True
+            r -= 1
+
+        return mask
+
+    def generate(self):
+        V = self.L_decomp[1]
+        mask = self._draw_k_mask()
+
+        V = V[:, mask]
+        Y = np.zeros(np.sum(mask), dtype=np.int32)
+
+        for i in np.arange(Y.size - 1, -1, -1):
+            probs = np.sum(np.square(V), axis=1) / np.sum(np.square(V))
+            Y[i] = np.where(np.random.rand(1) <= np.cumsum(probs))[0][0]
+            j = np.where(V[Y[i], :])[0][0]
+
+            Vc = np.tile(V[:, [j]], (1, V.shape[1] - 1)) * np.delete(V[Y[i], :], j) / V[Y[i], j]
+            V = np.delete(V, j, axis=1) - Vc
+            if V.size > 0:
+                V = np.linalg.qr(V)[0]
+
+        M = super(DPPDesign, self).generate()
+        return M[np.sort(Y), :]

--- a/testing/test_design.py
+++ b/testing/test_design.py
@@ -40,3 +40,9 @@ class TestFactorialDesign(_TestDesign, unittest.TestCase):
         for i in range(1, self.domain.size + 1):
             self.assertTrue(np.all(np.any(A[i - 1, :] - np.linspace(-i, 2 * i, 4)[:, None] < 1e-4, axis=0)),
                             msg="Generated off-grid.")
+
+
+class TestDPPDesign(_TestDesign, unittest.TestCase):
+    @_TestDesign.design.getter
+    def design(self):
+        return GPflowOpt.design.DPPDesign(5, self.domain)


### PR DESCRIPTION
As we don't have any other designs but random and grids yet, I tried the suggestion in GPflow/GPflow#397 and implemented a design sampling from determinantal point processes. 

It seems kind of cool, especially for larger designs its doing a great job:
![dpp100](https://cloud.githubusercontent.com/assets/767772/26033452/ee5d6738-38ac-11e7-8135-9af51281bd46.png)

However, for smaller designs the results vary a lot when running the same configuration twice:
![dpp10a](https://cloud.githubusercontent.com/assets/767772/26033454/fb1b3e32-38ac-11e7-9c8e-59c03de7cedb.png)
![dpp10b](https://cloud.githubusercontent.com/assets/767772/26033456/fdd2d586-38ac-11e7-9240-01033a96126d.png)

Also the size of the discretization of the domain and the lengthscales of the RBF used for the L matrix seem rather crucial. Before this can be merged,  those should be configured automatically. 
I guess a more coarse discretization for small designs makes sense, and the lengthscale should be proportional to the size of the design.
