### PR TITLE
Acquisition aggregation improvements

### DIFF
--- a/GPflowOpt/acquisition.py
+++ b/GPflowOpt/acquisition.py
@@ -113,12 +113,12 @@ class Acquisition(Parameterized):
 
     def __add__(self, other):
         if isinstance(other, AcquisitionSum):
-            return AcquisitionSum([self, *other.operands.sorted_params])
+            return AcquisitionSum([self] + other.operands.sorted_params)
         return AcquisitionSum([self, other])
 
     def __mul__(self, other):
         if isinstance(other, AcquisitionProduct):
-            return AcquisitionProduct([self, *other.operands.sorted_params])
+            return AcquisitionProduct([self] + other.operands.sorted_params)
         return AcquisitionProduct([self, other])
 
 
@@ -218,7 +218,7 @@ class AcquisitionSum(AcquisitionAggregationOperator):
         if isinstance(other, AcquisitionSum):
             return AcquisitionSum(self.operands.sorted_params + other.operands.sorted_params)
         else:
-            return AcquisitionSum([*self.operands.sorted_params, other])
+            return AcquisitionSum(self.operands.sorted_params + [other])
 
 
 class AcquisitionProduct(AcquisitionAggregationOperator):
@@ -229,4 +229,4 @@ class AcquisitionProduct(AcquisitionAggregationOperator):
         if isinstance(other, AcquisitionProduct):
             return AcquisitionProduct(self.operands.sorted_params + other.operands.sorted_params)
         else:
-            return AcquisitionProduct([*self.operands.sorted_params, other])
+            return AcquisitionProduct(self.operands.sorted_params + [other])

--- a/GPflowOpt/acquisition.py
+++ b/GPflowOpt/acquisition.py
@@ -42,7 +42,7 @@ class Acquisition(Parameterized):
         self.models = ParamList(np.atleast_1d(models).tolist())
         self._default_params = list(map(lambda m: m.get_free_state(), self.models))
 
-        assert(optimize_restarts >= 0)
+        assert (optimize_restarts >= 0)
         self._optimize_restarts = optimize_restarts
         self._optimize_all()
 
@@ -112,10 +112,14 @@ class Acquisition(Parameterized):
         return self._build_acquisition_wrapper(Xcand, gradients=False)
 
     def __add__(self, other):
-        return AcquisitionSum(self, other)
+        if isinstance(other, AcquisitionSum):
+            return AcquisitionSum([self, *other.operands.sorted_params])
+        return AcquisitionSum([self, other])
 
     def __mul__(self, other):
-        return AcquisitionProduct(self, other)
+        if isinstance(other, AcquisitionProduct):
+            return AcquisitionProduct([self, *other.operands.sorted_params])
+        return AcquisitionProduct([self, other])
 
 
 class ExpectedImprovement(Acquisition):
@@ -135,8 +139,6 @@ class ExpectedImprovement(Acquisition):
         # Obtain the lowest posterior mean for the previous evaluations
         samples_mean, _ = self.models[0].predict_f(self.data[0])
         self.fmin.set_data(np.min(samples_mean, axis=0))
-        # samples_mean, _ = self.models[0].build_predict(self.data[0])
-        # self.fmin = tf.reduce_min(samples_mean, axis=0)
 
     def build_acquisition(self, Xcand):
         # Obtain predictive distributions for candidates
@@ -168,47 +170,63 @@ class ProbabilityOfFeasibility(Acquisition):
         return normal.cdf(tf.constant(0.0, dtype=float_type), name=self.__class__.__name__)
 
 
-class AcquisitionBinaryOperator(Acquisition):
-    """
-    Base class for implementing binary operators for acquisition functions, for defining joint acquisition functions
-    """
-
-    def __init__(self, lhs, rhs, oper):
-        super(AcquisitionBinaryOperator, self).__init__()
-        assert isinstance(lhs, Acquisition)
-        assert isinstance(rhs, Acquisition)
-        self.lhs = lhs
-        self.rhs = rhs
+class AcquisitionAggregationOperator(Acquisition):
+    def __init__(self, operands, oper):
+        super(AcquisitionAggregationOperator, self).__init__()
+        for operand in operands:
+            assert isinstance(operand, Acquisition)
+        self.operands = ParamList(operands)
         self._oper = oper
 
     @Acquisition.data.getter
     def data(self):
-        lhsX, lhsY = self.lhs.data
-        rhsX, rhsY = self.rhs.data
+        X = self.operands[0].data[0]
+        Ys = map(lambda operand: operand.data[1], self.operands)
+
         if self._tf_mode:
-            return lhsX, tf.concat((lhsY, rhsY), 1)
+            return X, tf.concat(list(Ys), 1)
         else:
-            return lhsX, np.hstack((lhsY, rhsY))
+            return X, np.hstack(Ys)
 
     def set_data(self, X, Y):
-        offset_lhs = self.lhs.set_data(X, Y)
-        offset_rhs = self.rhs.set_data(X, Y[:, offset_lhs:])
-        return offset_lhs + offset_rhs
+        offset = 0
+        for operand in self.operands:
+            offset += operand.set_data(X, Y[:, offset:])
+        return offset
 
     def constraint_indices(self):
-        offset = self.lhs.data[1].shape[1]
-        return np.hstack((self.lhs.constraint_indices(), offset + self.rhs.constraint_indices()))
+        offset = [0]
+        idx = []
+        for operand in self.operands:
+            idx.append(operand.constraint_indices())
+            offset.append(operand.data[1].shape[1])
+        return np.hstack([i + o for i, o in zip(idx, offset[:-1])])
 
     def build_acquisition(self, Xcand):
-        return self._oper(self.lhs.build_acquisition(Xcand), self.rhs.build_acquisition(Xcand),
-                          name=self.__class__.__name__)
+        return self._oper(tf.concat(list(map(lambda operand: operand.build_acquisition(Xcand), self.operands)), 1),
+                          axis=1, keep_dims=True, name=self.__class__.__name__)
+
+    def __getitem__(self, item):
+        return self.operands[item]
 
 
-class AcquisitionSum(AcquisitionBinaryOperator):
-    def __init__(self, lhs, rhs):
-        super(AcquisitionSum, self).__init__(lhs, rhs, tf.add)
+class AcquisitionSum(AcquisitionAggregationOperator):
+    def __init__(self, operands):
+        super(AcquisitionSum, self).__init__(operands, tf.reduce_sum)
+
+    def __add__(self, other):
+        if isinstance(other, AcquisitionSum):
+            return AcquisitionSum(self.operands.sorted_params + other.operands.sorted_params)
+        else:
+            return AcquisitionSum([*self.operands.sorted_params, other])
 
 
-class AcquisitionProduct(AcquisitionBinaryOperator):
-    def __init__(self, lhs, rhs):
-        super(AcquisitionProduct, self).__init__(lhs, rhs, tf.multiply)
+class AcquisitionProduct(AcquisitionAggregationOperator):
+    def __init__(self, operands):
+        super(AcquisitionProduct, self).__init__(operands, tf.reduce_prod)
+
+    def __mul__(self, other):
+        if isinstance(other, AcquisitionProduct):
+            return AcquisitionProduct(self.operands.sorted_params + other.operands.sorted_params)
+        else:
+            return AcquisitionProduct([*self.operands.sorted_params, other])

--- a/testing/test_acquisition.py
+++ b/testing/test_acquisition.py
@@ -90,8 +90,9 @@ class _TestAcquisition(object):
         self.assertEqual(len(self.acquisition.models), 1, msg="Model list has incorrect length.")
         self.assertEqual(self.acquisition.models[0], self.model, msg="Incorrect model stored in ExpectedImprovement")
         self.assertEqual(len(self.acquisition._default_params), 1)
-        self.assertTrue(np.allclose(np.sort(self.acquisition._default_params[0]), np.sort(np.array([0.5413]*4)), atol=1e-2),
-                        msg="Initial hypers improperly stored")
+        self.assertTrue(
+            np.allclose(np.sort(self.acquisition._default_params[0]), np.sort(np.array([0.5413] * 4)), atol=1e-2),
+            msg="Initial hypers improperly stored")
 
 
 class TestExpectedImprovement(_TestAcquisition, unittest.TestCase):
@@ -183,17 +184,17 @@ class TestLowerConfidenceBound(_TestAcquisition, unittest.TestCase):
         design = GPflowOpt.design.RandomDesign(200, self.domain).generate()
         p = self.model.predict_f(design)[0]
         q = self.acquisition.evaluate(design)
-        np.testing.assert_array_less(q,p)
+        np.testing.assert_array_less(q, p)
 
     def test_LCB_validity_2(self):
         design = GPflowOpt.design.RandomDesign(200, self.domain).generate()
         self.acquisition.sigma = 0
         p = self.model.predict_f(design)[0]
         q = self.acquisition.evaluate(design)
-        np.testing.assert_allclose(q,p)
+        np.testing.assert_allclose(q, p)
 
 
-class _TestAcquisitionAggregationOperator(_TestAcquisition):
+class _TestAcquisitionAggregation(_TestAcquisition):
     def test_object_integrity(self):
         for oper in self.acquisition.operands:
             self.assertTrue(isinstance(oper, GPflowOpt.acquisition.Acquisition),
@@ -201,7 +202,7 @@ class _TestAcquisitionAggregationOperator(_TestAcquisition):
         self.assertEqual(len(self.acquisition._default_params), 0)
 
     def test_data(self):
-        super(_TestAcquisitionAggregationOperator, self).test_data()
+        super(_TestAcquisitionAggregation, self).test_data()
         np.testing.assert_allclose(self.acquisition.data[0], self.acquisition[0].data[0],
                                    err_msg="Samples should be equal for all operands")
         np.testing.assert_allclose(self.acquisition.data[0], self.acquisition[1].data[0],
@@ -212,7 +213,7 @@ class _TestAcquisitionAggregationOperator(_TestAcquisition):
                                    err_msg="Value should be horizontally concatenated")
 
 
-class TestAcquisitionSum(_TestAcquisitionAggregationOperator, unittest.TestCase):
+class TestAcquisitionSum(_TestAcquisitionAggregation, unittest.TestCase):
     def setUp(self):
         super(TestAcquisitionSum, self).setUp()
         self.models = [self.create_parabola_model(), self.create_parabola_model()]
@@ -241,7 +242,7 @@ class TestAcquisitionSum(_TestAcquisitionAggregationOperator, unittest.TestCase)
                                    err_msg="Sum of two EI should return no constraints")
 
 
-class TestAcquisitionProduct(_TestAcquisitionAggregationOperator, unittest.TestCase):
+class TestAcquisitionProduct(_TestAcquisitionAggregation, unittest.TestCase):
     def setUp(self):
         super(TestAcquisitionProduct, self).setUp()
         self.models = [self.create_parabola_model(), self.create_parabola_model()]


### PR DESCRIPTION
Avoids tree structures with great depth with summing or multiplying many acquisition functions. This also reduces the size of the TF graph (by using reduce operations rather than many additions/multiplications). Useful for later implementation of #18 .