### PR TITLE
Data object

### DIFF
--- a/GPflowOpt/__init__.py
+++ b/GPflowOpt/__init__.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 from . import acquisition
+from . import data
 from . import domain
 from .bo import BayesianOptimizer
 from . import optim

--- a/GPflowOpt/bo.py
+++ b/GPflowOpt/bo.py
@@ -69,11 +69,11 @@ class BayesianOptimizer(Optimizer):
         :param newX: samples (# new samples x indim)
         :param newY: values obtained by evaluating the objective and constraint functions (# new samples x # targets)
         """
-        assert self.acquisition.data[0].shape[1] == newX.shape[-1]
-        assert self.acquisition.data[1].shape[1] == newY.shape[-1]
+        assert self.acquisition.data.X.shape[1] == newX.shape[-1]
+        assert self.acquisition.data.Y.shape[1] == newY.shape[-1]
         assert newX.shape[0] == newY.shape[0]
-        X = np.vstack((self.acquisition.data[0], newX))
-        Y = np.vstack((self.acquisition.data[1], newY))
+        X = np.vstack((self.acquisition.data.X, newX))
+        Y = np.vstack((self.acquisition.data.Y, newY))
         self.acquisition.set_data(X, Y)
 
     def _evaluate_objectives(self, X, fxs):
@@ -91,7 +91,7 @@ class BayesianOptimizer(Optimizer):
             assert evaluations.shape[1] == self.acquisition.data[1].shape[1]
             return evaluations, np.zeros((X.shape[0], 0))
         else:
-            return np.empty((0, self.acquisition.data[1].shape[1])), np.zeros((0, 0))
+            return np.empty((0, self.acquisition.data.Y.shape[1])), np.zeros((0, 0))
 
     def _create_bo_result(self, success, message):
         """
@@ -182,5 +182,5 @@ class BayesianOptimizer(Optimizer):
         try:
             yield
         except Exception as e:
-            np.savez('failed_bopt_{0}'.format(id(e)), X=self.acquisition.data[0], Y=self.acquisition.data[1])
+            self.acquisition.data.save('failed_bopt_{0}'.format(id(e)))
             raise

--- a/GPflowOpt/data.py
+++ b/GPflowOpt/data.py
@@ -1,0 +1,72 @@
+# Copyright 2017 Joachim van der Herten
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from collections import namedtuple, Iterable
+
+import numpy as np
+import tensorflow as tf
+
+
+class Data(namedtuple('Data', ['X', 'Y'])):
+    """
+    Corresponds to the input data X which is the same for every model,
+    and column-wise concatenation of the Y data over all models
+    """
+
+    @classmethod
+    def create(cls, models, tf_mode=False):
+        """
+        Given an iterable container of models, condense their contained training data into a Data object.
+        :param models: iterable of models
+        :param tf_mode: (default: False) is the object requested in tf_mode or not?
+        :return: Data object
+        """
+        #assert isinstance(models, Iterable)
+
+        if tf_mode:
+            X, Y = models[0].X, tf.concat(list(map(lambda model: model.Y, models)), 1)
+        else:
+            X, Y = models[0].X.value, np.hstack(map(lambda model: model.Y.value, models))
+        return cls(X=X, Y=Y)
+
+    def save(self, fname):
+        """
+        Dump the data to a file (used for the failsafe context of BayesianOptimizer)
+        :param fname: path to file to save data to.
+        """
+        np.savez(fname, **self._asdict())
+
+    def update_model(self, model, Ycols=None):
+        """
+        Update the data of a given model.
+        :param model: model to be updated.
+        :param Ycols: (optional) columns of output data (Y) to be passed into the model. If unspecified, the first P
+         columns are used, with P equal to the current number of outputs of the model.
+        """
+        model.X = self.X
+        Ycols = np.arange(self.Y.shape[1]) if Ycols is None else Ycols
+        model.Y = self.Y[:, np.atleast_1d(Ycols)]
+
+    def add(self, Xn, Yn):
+        """
+        Given new X/Y, add them to the data object. The second dimension of Xn and Yn must match those of X/Y in Data
+        :param Xn: New input samples. 2D ndarray n x d
+        :param Yn: New output samples. 2D ndarray n x p
+        :return: new Data object, containing the old data augmented with the new data.
+        """
+        assert self.X.shape[1] == Xn.shape[-1]
+        assert self.Y.shape[1] == Yn.shape[-1]
+        X = np.vstack((self.X, Xn))
+        Y = np.vstack((self.Y, Yn))
+        return self.__class__(X=X, Y=Y)

--- a/testing/test_objective.py
+++ b/testing/test_objective.py
@@ -65,6 +65,8 @@ def add_batch_apply_no_grad(Xflat):
 
 class TestDecorators(unittest.TestCase):
 
+    _multiprocess_can_split = True
+
     @staticmethod
     def check_reference(f, g, X):
         np.testing.assert_almost_equal(f, ref_function(X)[0])

--- a/testing/test_optimizers.py
+++ b/testing/test_optimizers.py
@@ -30,6 +30,7 @@ class KeyboardRaiser:
 
 
 class _TestOptimizer(object):
+
     _multiprocess_can_split_ = True
 
     def setUp(self):
@@ -185,13 +186,14 @@ class TestBayesianOptimizer(_TestOptimizer, unittest.TestCase):
         self.optimizer.acquisition.models[0]._needs_recompile = True
         with self.assertRaises(RuntimeError) as e:
             with self.optimizer.failsafe():
-                self.optimizer.acquisition.set_data(X, Y)
+                self.optimizer.acquisition.set_data(GPflowOpt.data.Data(X=X, Y=Y))
 
         fname = 'failed_bopt_{0}.npz'.format(id(e.exception))
         self.assertTrue(os.path.isfile(fname))
         data = np.load(fname)
         np.testing.assert_almost_equal(data['X'], X)
         np.testing.assert_almost_equal(data['Y'], Y)
+        os.remove(fname)
 
 
 class TestBayesianOptimizerConfigurations(unittest.TestCase):


### PR DESCRIPTION
Last week, I had a discussion on the data storage strategy of GPflowOpt, and the lack of a specific object managing the data. As models require the data at some point (even more, currently they need the data in their constructor) I didn't see a reason to split this further and increase synchronization needs.

However, it got me thinking about situations where not only X/Y is expected. Say, in case of gradient-based BO. I'm undecided if this scenario will be added by default, but I'd like the framework to be capable of supporting such scenario.

Therefore, as a first step I introduced a data object which is returned from the data property and fed into set_data. It takes care of updating models etc so extending beyond X/Y becomes possible. Currently I did not make some sort of shared data object yet which can be updated, I'm a little concerned this might complicate things, although I'm considering it. Some additional tests are still to be added as well.