### PR TITLE
Added indexing for domain objects for string and list-like

### DIFF
--- a/GPflowOpt/domain.py
+++ b/GPflowOpt/domain.py
@@ -46,6 +46,12 @@ class Domain(Parentable):
         assert isinstance(other, Domain)
         return Domain(self._parameters + other._parameters)
 
+    def __radd__(self, other):
+        if other == 0:
+            return self
+
+        return other + self
+
     @property
     def size(self):
         """
@@ -76,8 +82,15 @@ class Domain(Parentable):
         for v in chain(*map(iter, self._parameters)):
             yield v
 
-    def __getitem__(self, item):
-        return self._parameters[item]
+    def __getitem__(self, items):
+        if isinstance(items, list):
+            return sum([self[item] for item in items])
+
+        if isinstance(items, str):
+            labels = [param.label for param in self._parameters]
+            items = labels.index(items)
+
+        return self._parameters[items]
 
     def __rshift__(self, other):
         assert(self.size == other.size)

--- a/GPflowOpt/domain.py
+++ b/GPflowOpt/domain.py
@@ -46,12 +46,6 @@ class Domain(Parentable):
         assert isinstance(other, Domain)
         return Domain(self._parameters + other._parameters)
 
-    def __radd__(self, other):
-        if other == 0:
-            return self
-
-        return other + self
-
     @property
     def size(self):
         """
@@ -84,7 +78,7 @@ class Domain(Parentable):
 
     def __getitem__(self, items):
         if isinstance(items, list):
-            return sum([self[item] for item in items])
+            return np.sum([self[item] for item in items])
 
         if isinstance(items, str):
             labels = [param.label for param in self._parameters]

--- a/testing/test_domain.py
+++ b/testing/test_domain.py
@@ -19,6 +19,9 @@ class TestContinuousParameter(unittest.TestCase):
         p.lower = 1
         self.assertEqual(p.lower, 1, msg="After assignment, lower should equal 2")
 
+        p = np.sum([GPflowOpt.domain.ContinuousParameter("x1", 0, 1)])
+        self.assertTrue(p.size == 1, msg="Construction of domain by list using sum failed")
+
     def test_equality(self):
         p = GPflowOpt.domain.ContinuousParameter("x1", 0, 1)
         pne = GPflowOpt.domain.ContinuousParameter("x1", 0, 2)

--- a/testing/test_domain.py
+++ b/testing/test_domain.py
@@ -35,7 +35,7 @@ class TestContinuousParameter(unittest.TestCase):
         self.assertEqual(p, pne, msg="Should be equal after adjusting bounds")
 
     def test_indexing(self):
-        p = sum([GPflowOpt.domain.ContinuousParameter("x1", 0, 1),
+        p = np.sum([GPflowOpt.domain.ContinuousParameter("x1", 0, 1),
                  GPflowOpt.domain.ContinuousParameter("x2", 0, 1),
                  GPflowOpt.domain.ContinuousParameter("x3", 0, 1),
                  GPflowOpt.domain.ContinuousParameter("x4", 0, 1)])

--- a/testing/test_domain.py
+++ b/testing/test_domain.py
@@ -31,6 +31,18 @@ class TestContinuousParameter(unittest.TestCase):
         p.upper = 2
         self.assertEqual(p, pne, msg="Should be equal after adjusting bounds")
 
+    def test_indexing(self):
+        p = sum([GPflowOpt.domain.ContinuousParameter("x1", 0, 1),
+                 GPflowOpt.domain.ContinuousParameter("x2", 0, 1),
+                 GPflowOpt.domain.ContinuousParameter("x3", 0, 1),
+                 GPflowOpt.domain.ContinuousParameter("x4", 0, 1)])
+
+        subdomain = p[['x4', 'x1', 2]]
+        self.assertTrue(subdomain.size == 3, msg="Subdomain should have size 3")
+        self.assertTrue(subdomain[0].label == 'x4', msg="Subdomain's first parameter should be 'x4'")
+        self.assertTrue(subdomain[1].label == 'x1', msg="Subdomain's second parameter should be 'x1'")
+        self.assertTrue(subdomain[2].label == 'x3', msg="Subdomain's third parameter should be 'x3'")
+
     def test_containment(self):
         p = GPflowOpt.domain.ContinuousParameter("x1", 0, 1)
         self.assertIn(0, p, msg="Point is within domain")

--- a/testing/test_optimizers.py
+++ b/testing/test_optimizers.py
@@ -179,7 +179,7 @@ class TestBayesianOptimizer(_TestOptimizer, unittest.TestCase):
     def test_failsafe(self):
         X, Y = self.optimizer.acquisition.data[0], self.optimizer.acquisition.data[1]
         # Provoke cholesky faillure
-        self.optimizer.acquisition._optimize_restarts = 1
+        self.optimizer.acquisition.optimize_restarts = 1
         self.optimizer.acquisition.models[0].likelihood.variance.transform = GPflow.transforms.Identity()
         self.optimizer.acquisition.models[0].likelihood.variance = -5.0
         self.optimizer.acquisition.models[0]._needs_recompile = True


### PR DESCRIPTION
Now we can easily create subdomains:
subdomain = domain[['velocity', 'acc']]

I also overloaded the __radd__ operator which is required for using the sum() operator to create a domain from a list of Parameter objects. For a list with only one Parameter python starts from an int 0 and adds a single Parameter, this case is addressed by the __radd__ operator.