### PR TITLE
Fixes the test_failsafe test on windows

### DIFF
--- a/testing/test_optimizers.py
+++ b/testing/test_optimizers.py
@@ -189,9 +189,9 @@ class TestBayesianOptimizer(_TestOptimizer, unittest.TestCase):
 
         fname = 'failed_bopt_{0}.npz'.format(id(e.exception))
         self.assertTrue(os.path.isfile(fname))
-        data = np.load(fname)
-        np.testing.assert_almost_equal(data['X'], X)
-        np.testing.assert_almost_equal(data['Y'], Y)
+        with np.load(fname) as data:
+            np.testing.assert_almost_equal(data['X'], X)
+            np.testing.assert_almost_equal(data['Y'], Y)
         os.remove(fname)
 
 


### PR DESCRIPTION
Should be a fairly simple fix for test_failsafe.

When opening an npz file it should be explicitly closed. On windows this causes problems when trying to remove the test npz file.