### PR TITLE
Make LCB sigma parameter a dataholder so it can be changed (#83)

### DIFF
--- a/gpflowopt/acquisition/lcb.py
+++ b/gpflowopt/acquisition/lcb.py
@@ -14,6 +14,9 @@
 
 from .acquisition import Acquisition
 
+from gpflow.param import DataHolder
+import numpy as np
+
 import tensorflow as tf
 
 
@@ -32,7 +35,7 @@ class LowerConfidenceBound(Acquisition):
         :param sigma: See formula, the higher the more exploration
         """
         super(LowerConfidenceBound, self).__init__(model)
-        self.sigma = sigma
+        self.sigma = DataHolder(np.array(sigma))
 
     def build_acquisition(self, Xcand):
         candidate_mean, candidate_var = self.models[0].build_predict(Xcand)

--- a/testing/test_implementations.py
+++ b/testing/test_implementations.py
@@ -152,7 +152,7 @@ class TestLowerConfidenceBound(GPflowOptTestCase):
 
     def test_object_integrity(self):
         with self.test_session():
-            self.assertEqual(self.acquisition.sigma, 3.2)
+            self.assertEqual(self.acquisition.sigma.value, 3.2)
 
     def test_lcb_validity(self):
         with self.test_session():


### PR DESCRIPTION
The sigma parameter in LCB couldn't be changed. There quite some approaches which compute sigma every iteration so we should support this use case.