### PR TITLE
Bump version to 0.1.1

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,2 +1,5 @@
 # Release 0.1.0
 Initial release of GPflowOpt
+
+# Release 0.1.1
+Small bugfix release

--- a/gpflowopt/_version.py
+++ b/gpflowopt/_version.py
@@ -12,4 +12,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-__version__ = "0.1.0"  # pragma: no cover
+__version__ = "0.1.1"  # pragma: no cover


### PR DESCRIPTION
Lets make a minor release before switching master to use gpflow 1.0.

This will also be the last release to support python 2.