### PR TITLE
Bug fix in pareto.py, Pareto::divide_conquer_nd

### DIFF
--- a/gpflowopt/pareto.py
+++ b/gpflowopt/pareto.py
@@ -20,6 +20,7 @@ import tensorflow as tf
 
 np_int_type = np_float_type = np.int32 if settings.dtypes.int_type is tf.int32 else np.int64
 float_type = settings.dtypes.float_type
+stability = settings.numerics.jitter_level
 
 
 class BoundedVolumes(Parameterized):
@@ -193,6 +194,7 @@ class Pareto(Parameterized):
         # Start with one cell covering the whole front
         dc = [(np.zeros(outdim, dtype=np_int_type),
                (int(pf_ext_idx.shape[0]) - 1) * np.ones(outdim, dtype=np_int_type))]
+        
         total_size = np.prod(max_pf - min_pf)
 
         # Start divide and conquer until we processed all cells
@@ -205,12 +207,12 @@ class Pareto(Parameterized):
             ub  = pf_ext[pf_ext_idx[cell[1], arr], arr]
 
             # Acceptance test:
-            if self._is_test_required((ub - 1e-6) < self.front.value):
+            if self._is_test_required((ub - stability) < self.front.value):
                 # Cell is a valid integral bound: store
                 self.bounds.append(pf_ext_idx[cell[0], np.arange(outdim)],
                                    pf_ext_idx[cell[1], np.arange(outdim)])
             # Reject test:
-            elif self._is_test_required((lb + 1e-6) < self.front.value):
+            elif self._is_test_required((lb + stability) < self.front.value):
                 # Cell can not be discarded: calculate the size of the cell
                 dc_dist = cell[1] - cell[0]
                 hc = BoundedVolumes(pf_ext[pf_ext_idx[cell[0], np.arange(outdim)], np.arange(outdim)],

--- a/gpflowopt/pareto.py
+++ b/gpflowopt/pareto.py
@@ -205,13 +205,11 @@ class Pareto(Parameterized):
             ub  = pf_ext[pf_ext_idx[cell[1], arr], arr]
 
             # Acceptance test:
-            # if self._is_test_required((cell[1] - 0.5) < pseudo_pf):
             if self._is_test_required((ub - 1e-6) < self.front.value):
                 # Cell is a valid integral bound: store
                 self.bounds.append(pf_ext_idx[cell[0], np.arange(outdim)],
                                    pf_ext_idx[cell[1], np.arange(outdim)])
             # Reject test:
-            # elif self._is_test_required((cell[0] + 0.5) < pseudo_pf):
             elif self._is_test_required((lb + 1e-6) < self.front.value):
                 # Cell can not be discarded: calculate the size of the cell
                 dc_dist = cell[1] - cell[0]
@@ -280,18 +278,3 @@ class Pareto(Parameterized):
         lb = tf.reshape(tf.gather_nd(pseudo_pf, lb_idx), [D, N])
         hv = tf.reduce_sum(tf.reduce_prod(ub - lb, 0))
         return tf.reduce_prod(R - min_pf) - hv
-
-if __name__ == '__main__':
-    r0  = np.array([4.0, 4.0, 4.0])
-
-    d21 = np.array([[2.0, 2.0, 0.0],
-                    [2.0, 0.0, 1.0],
-                    [3.0, 1.0, 0.0]])  # 29 v.s. 28
-    prt = Pareto(d21)
-    print prt.hypervolume(r0)  # should be 29
-
-    d21 = np.array([[2.0, 0.0, 1.0],
-                    [2.0, 2.0, 0.0],
-                    [3.0, 1.0, 0.0]])  # 29 v.s. 32
-    prt = Pareto(d21)
-    print prt.hypervolume(r0)  # should be 29

--- a/gpflowopt/pareto.py
+++ b/gpflowopt/pareto.py
@@ -200,13 +200,19 @@ class Pareto(Parameterized):
             # Process test cell
             cell = dc.pop()
 
+            arr = np.arange(outdim)
+            lb  = pf_ext[pf_ext_idx[cell[0], arr], arr]
+            ub  = pf_ext[pf_ext_idx[cell[1], arr], arr]
+
             # Acceptance test:
-            if self._is_test_required((cell[1] - 0.5) < pseudo_pf):
+            # if self._is_test_required((cell[1] - 0.5) < pseudo_pf):
+            if self._is_test_required((ub - 1e-6) < self.front.value):
                 # Cell is a valid integral bound: store
                 self.bounds.append(pf_ext_idx[cell[0], np.arange(outdim)],
                                    pf_ext_idx[cell[1], np.arange(outdim)])
             # Reject test:
-            elif self._is_test_required((cell[0] + 0.5) < pseudo_pf):
+            # elif self._is_test_required((cell[0] + 0.5) < pseudo_pf):
+            elif self._is_test_required((lb + 1e-6) < self.front.value):
                 # Cell can not be discarded: calculate the size of the cell
                 dc_dist = cell[1] - cell[0]
                 hc = BoundedVolumes(pf_ext[pf_ext_idx[cell[0], np.arange(outdim)], np.arange(outdim)],
@@ -274,3 +280,18 @@ class Pareto(Parameterized):
         lb = tf.reshape(tf.gather_nd(pseudo_pf, lb_idx), [D, N])
         hv = tf.reduce_sum(tf.reduce_prod(ub - lb, 0))
         return tf.reduce_prod(R - min_pf) - hv
+
+if __name__ == '__main__':
+    r0  = np.array([4.0, 4.0, 4.0])
+
+    d21 = np.array([[2.0, 2.0, 0.0],
+                    [2.0, 0.0, 1.0],
+                    [3.0, 1.0, 0.0]])  # 29 v.s. 28
+    prt = Pareto(d21)
+    print prt.hypervolume(r0)  # should be 29
+
+    d21 = np.array([[2.0, 0.0, 1.0],
+                    [2.0, 2.0, 0.0],
+                    [3.0, 1.0, 0.0]])  # 29 v.s. 32
+    prt = Pareto(d21)
+    print prt.hypervolume(r0)  # should be 29

--- a/testing/unit/test_pareto.py
+++ b/testing/unit/test_pareto.py
@@ -28,6 +28,17 @@ class TestPareto(GPflowOptTestCase):
         self.p_generic = gpflowopt.pareto.Pareto(np.zeros((1, 2)))
         self.p_generic.update(objective_scores, generic_strategy=True)
 
+        scores_3d_set1 = np.array([[2.0, 2.0, 0.0],
+                                   [2.0, 0.0, 1.0],
+                                   [3.0, 1.0, 0.0]])
+        scores_3d_set2 = np.array([[2.0, 0.0, 1.0],
+                                   [2.0, 2.0, 0.0],
+                                   [3.0, 1.0, 0.0]])
+        self.p_3d_set1 = gpflowopt.pareto.Pareto(np.zeros((1, 3)))
+        self.p_3d_set1.update(scores_3d_set1)
+        self.p_3d_set2 = gpflowopt.pareto.Pareto(np.zeros((1, 3)))
+        self.p_3d_set2.update(scores_3d_set2)
+
     def test_update(self):
         np.testing.assert_almost_equal(self.p_2d.bounds.lb.value, np.array([[0, 0], [1, 0], [2, 0], [3, 0]]),
                                        err_msg='LBIDX incorrect.')
@@ -54,3 +65,6 @@ class TestPareto(GPflowOptTestCase):
 
         np.testing.assert_almost_equal(self.p_2d.hypervolume([1, 1]), self.p_generic.hypervolume([1, 1]), decimal=20,
                                        err_msg='hypervolume of different strategies incorrect.')
+
+        np.testing.assert_equal(self.p_3d_set1.hypervolume([4, 4, 4]), 29.0, err_msg='3D hypervolume incorrect.')
+        np.testing.assert_equal(self.p_3d_set2.hypervolume([4, 4, 4]), 29.0, err_msg='3D hypervolume incorrect.')


### PR DESCRIPTION
The algorithm in `Pareto::divide_conquer_nd` fails when two points in the Pareto set have the *same* value in a certain dimension. An example is included in the modified `pareto.py`:
The Pareto set `d21` contains three points, two of which have a value of 2.0 in the first dimension. Ordering the three points results in different ways results in different values of the hypervolume (28 and 32), which are all wrong (should be 29).

The issue is in the dominance test associated with `_is_test_required` method and `pseudo_pf`. The array `pseudo_pf` assigns different ranks to the same values. Therefore, by reordering the Pareto set in the test case, different pseudo Pareto sets are generated for the same Pareto set.

I figured out two ways for the fix. One is to fix `pseudo_pf` by sorting the Pareto set such that the same values are assigned the same rank (e.g. using scipy.stats.rankdata). The other is to fix the dominance test by checking the *actual* Pareto set. The first one leads to more iterations in the algorithm. Therefore, I implemented the second approach in `pareto.py` with a minimum modification - although some simplifications of the code are possible.